### PR TITLE
Adição do endpoint de login, refresh e verify (POST) de tokens

### DIFF
--- a/cadernetaDigital/settings.py
+++ b/cadernetaDigital/settings.py
@@ -124,4 +124,7 @@ SIMPLE_JWT = {
     'REFRESH_TOKEN_LIFETIME': timedelta(days=10),
     'ROTATE_REFRESH_TOKENS': False,
     'BLACKLIST_AFTER_ROTATION': True,
+    # Campo identificador padrão do usuario
+    'USER_ID_FIELD': 'idUsuario',
 }
+

--- a/core/tests/mixin.py
+++ b/core/tests/mixin.py
@@ -22,16 +22,25 @@ class APITestMixin:
 
     def get_header_credencial(self):
         token = RefreshToken.for_user(self.user)
-        return str(token)
+        return str(token.access_token)
 
     def get_client(self):
         client = APIClient()
-        # client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.get_header_credencial())
+        client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.get_header_credencial())
         return client
 
     @classmethod
     def setUpClass(cls):
-        cls.setUp = APITestMixin.setUp
+        # NOTE: Se o setUp não for na APITestMixin, executa ele primeiro e
+        # após isso executa o específico da classe sendo executada
+        if not isinstance(APITestMixin, cls) and cls.setUp is not APITestMixin.setUp:
+            setUp_original = cls.setUp
+
+            def setUpNovo(self, *args, **kwargs):
+                APITestMixin.setUp(self)
+                setUp_original(self, *args, **kwargs)
+
+            cls.setUp = setUpNovo
         super().setUpClass()
 
     def setUp(self):

--- a/usuario/serializers/token.py
+++ b/usuario/serializers/token.py
@@ -12,4 +12,6 @@ class TokenObtainPairSerializer(TokenObtainPairSerializer):
         data = super().validate(attrs)
         data.update({'idUsuario': str(self.user.idUsuario)})
         data.update({'cpf': self.user.cpf})
+        data.update({'nome': self.user.nome})
+        data.update({'tipo': self.user.tipo})
         return data

--- a/usuario/serializers/token.py
+++ b/usuario/serializers/token.py
@@ -1,0 +1,15 @@
+from usuario.models import Usuario
+
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+
+
+class TokenObtainPairSerializer(TokenObtainPairSerializer):
+    default_error_messages = {
+        'no_active_account': 'Nenhuma conta encontrada. CPF ou senha incorretos.'
+    }
+
+    def validate(self, attrs):
+        data = super().validate(attrs)
+        data.update({'idUsuario': str(self.user.idUsuario)})
+        data.update({'cpf': self.user.cpf})
+        return data

--- a/usuario/tests/recipes.py
+++ b/usuario/tests/recipes.py
@@ -5,4 +5,4 @@ from usuario.models import Usuario
 
 # FIXME: Por conta do tipo obrigatório, esse usuário está sendo
 # criado com um tipo fixo e pré-definido, mesmo não sendo um
-usuario = Recipe(Usuario, telefone='5561912345678')
+usuario = Recipe(Usuario, telefone='5561912345678', _fill_optional=True)

--- a/usuario/tests/views/test_token.py
+++ b/usuario/tests/views/test_token.py
@@ -20,7 +20,7 @@ class TokenObtainPairViewTest(APITestMixin, TestCase):
     def setUp(self):
         self.cpf = '30078206006'
         self.senha = 'senha_forte'
-        self.usuario = usuario_recipe.make(cpf=self.cpf)
+        self.usuario = usuario_recipe.make(cpf=self.cpf, nome=self.nome, tipo=self.tipo)
         self.usuario.set_password(self.senha)
         self.usuario.save(update_fields=['password'])
 
@@ -32,7 +32,7 @@ class TokenObtainPairViewTest(APITestMixin, TestCase):
         })
         self.assertEqual(response.status_code, 200, response.json())
 
-        for campo in ('idUsuario', 'cpf'):
+        for campo in ('idUsuario', 'cpf', 'nome', 'tipo'):
             with self.subTest(campo=campo):
                 self.assertEqual(response.json()[campo], getattr(self, campo))
 

--- a/usuario/tests/views/test_token.py
+++ b/usuario/tests/views/test_token.py
@@ -1,0 +1,120 @@
+from core.tests.mixin import APITestMixin
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+from django.contrib.auth.hashers import make_password
+
+from freezegun import freeze_time
+
+from rest_framework.reverse import reverse_lazy
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from usuario.tests.recipes import usuario as usuario_recipe
+
+
+class TokenObtainPairViewTest(APITestMixin, TestCase):
+    url = reverse_lazy('usuario-login')
+
+    def setUp(self):
+        self.cpf = '30078206006'
+        self.senha = 'senha_forte'
+        self.usuario = usuario_recipe.make(cpf=self.cpf)
+        self.usuario.set_password(self.senha)
+        self.usuario.save(update_fields=['password'])
+
+    def test_login(self):
+        self.idUsuario = str(self.usuario.idUsuario)
+        response = self.client.post(self.url, data={
+            'cpf': self.cpf,
+            'password': self.senha
+        })
+        self.assertEqual(response.status_code, 200, response.json())
+
+        for campo in ('idUsuario', 'cpf'):
+            with self.subTest(campo=campo):
+                self.assertEqual(response.json()[campo], getattr(self, campo))
+
+    def test_login_invalido(self):
+        response = self.client.post(self.url, data={
+            'cpf': self.cpf,
+            'password': 'senha_invalida'
+        })
+        self.assertEqual(response.status_code, 401, response.json())
+        self.assertIn(
+            'Nenhuma conta encontrada. CPF ou senha incorretos.',
+            response.json()['detail']
+        )
+
+
+class RefreshViewTest(APITestMixin, TestCase):
+    url = reverse_lazy('usuario-refresh')
+
+    def setUp(self):
+        self.cpf = '30078206006'
+        self.senha = 'senha_forte'
+        self.usuario = usuario_recipe.make(cpf=self.cpf)
+        self.usuario.set_password(self.senha)
+        self.usuario.save(update_fields=['password'])
+
+        with freeze_time("2022-1-1"):
+            self.refresh = RefreshToken.for_user(self.usuario)
+            self.access = self.refresh.access_token
+
+    @freeze_time('2022-1-8')
+    def test_refresh_do_token(self):
+        response = self.client.post(self.url, data={'refresh': str(self.refresh)})
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertIsNotNone(response.json().get('access'))
+
+    @freeze_time('2022-1-11')
+    def test_refresh_invalido(self):
+        response = self.client.post(self.url, data={'refresh': str(self.refresh)})
+        self.assertEqual(response.status_code, 401, response.json())
+        self.assertIn(
+            "Token 'exp' claim has expired",
+            response.json()['detail']
+        )
+
+
+class TokenVerifyViewTest(APITestMixin, TestCase):
+    url = reverse_lazy('usuario-verify')
+
+    def setUp(self):
+        self.cpf = '30078206006'
+        self.senha = 'senha_forte'
+        self.usuario = usuario_recipe.make(cpf=self.cpf)
+        self.usuario.set_password(self.senha)
+        self.usuario.save(update_fields=['password'])
+
+    def test_token_valido(self):
+        refresh = RefreshToken.for_user(self.usuario)
+        access = refresh.access_token
+
+        response = self.client.post(self.url, data={'token': str(access)})
+        self.assertEqual(response.status_code, 200, response.json())
+
+    def test_token_expirado_refresh_valido(self):
+        with freeze_time("2022-1-1"):
+            refresh = RefreshToken.for_user(self.usuario)
+            access = refresh.access_token
+
+        with freeze_time("2022-1-8"):
+            response = self.client.post(self.url, data={'token': str(refresh)})
+
+        self.assertEqual(response.status_code, 200, response.json())
+
+    def test_token_expirado(self):
+        with freeze_time("2022-1-1"):
+            refresh = RefreshToken.for_user(self.usuario)
+            access = refresh.access_token
+
+        with freeze_time("2022-1-20"):
+            response = self.client.post(self.url, data={'token': str(access)})
+
+        self.assertEqual(response.status_code, 401, response.json())
+        self.assertIn(
+            'Token is invalid or expired',
+            response.json()['detail']
+        )

--- a/usuario/tests/views/tests.py
+++ b/usuario/tests/views/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/usuario/urls.py
+++ b/usuario/urls.py
@@ -1,1 +1,15 @@
-urlpatterns = []
+from django.conf.urls import url
+from django.urls import include
+
+from rest_framework_simplejwt.views import TokenRefreshView, TokenVerifyView
+
+from usuario.views.token import TokenObtainPairView
+
+
+urlpatterns = [
+    url(r'^login/', include([
+        url(r'^$', TokenObtainPairView.as_view(), name='usuario-login'),
+        url(r'^refresh/$', TokenRefreshView.as_view(), name='usuario-refresh'),
+        url(r'^verify/$', TokenVerifyView.as_view(), name='usuario-verify'),
+    ]))
+]

--- a/usuario/views/token.py
+++ b/usuario/views/token.py
@@ -1,0 +1,7 @@
+from rest_framework_simplejwt.views import TokenObtainPairView
+
+from usuario.serializers.token import TokenObtainPairSerializer
+
+
+class TokenObtainPairView(TokenObtainPairView):
+    serializer_class = TokenObtainPairSerializer

--- a/usuario/views/usuario.py
+++ b/usuario/views/usuario.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.


### PR DESCRIPTION
## Descrição
<!-- - Descreva aqui as alterações a serem implementadas no projeto -->
Adição dos endpoint relacionados à tokens

## Está consertando alguma issue aberta?
<!-- - Se sim, informe aqui -->
- [#106](https://github.com/UnBArqDsw2021-2/2021.2_G4_CadernetaDeCampoDigital_docs/issues/106)

## Tarefas gerais realizadas
- Adição das views de login, refresh e verify dos tokens
- Adilção do serializer de login para retorno de informações úteis ao front
- Pequenos fixes no código