### PR TITLE
Adicionando endpoint DELETE para deletar o técnico de uma propriedade 

### DIFF
--- a/propriedade/tests/views/test_propriedade.py
+++ b/propriedade/tests/views/test_propriedade.py
@@ -219,12 +219,16 @@ class PropriedadeHistoricoPlantioAPIView(APITestMixin, TestCase):
 
     def setUp(self):
         self.propriedade = propriedade.make()
-        self.url = reverse_lazy(
-            "propriedade-historico-plantio", kwargs={'idPropriedade': self.propriedade.idPropriedade})
+        self.url = self.get_url()
         self.talhoes = talhao.make(idPropriedade=self.propriedade, _quantity=3)
         talhao.make(idPropriedade=self.propriedade, _quantity=2)
         for t in self.talhoes:
             plantio.make(talhao=t)
+
+    def get_url(self, idPropriedade=None):
+        if idPropriedade is None:
+            idPropriedade = self.propriedade.idPropriedade
+        return reverse_lazy("propriedade-historico-plantio", kwargs={'idPropriedade': idPropriedade})
 
     def test_lista_plantios_do_talhao(self):
         response = self.client.get(self.url)
@@ -232,14 +236,12 @@ class PropriedadeHistoricoPlantioAPIView(APITestMixin, TestCase):
         self.assertEqual(len(response.json()), 3)
 
     def test_nao_lista_plantio_de_outra_propriedade(self):
-        url = reverse_lazy(
-            "propriedade-historico-plantio", kwargs={'idPropriedade': self.propriedade.idPropriedade})
         propriedade_diferente = propriedade.make()
         talhoes = talhao.make(idPropriedade=propriedade_diferente, _quantity=3)
         for t in talhoes:
             plantio.make(talhao=t)
 
-        response = self.client.get(url)
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200, response.json())
         self.assertEqual(Plantio.objects.count(), 6)
         self.assertEqual(len(response.json()), 3)
@@ -251,8 +253,12 @@ class PropriedadeDeleteTecnicoAPIView(APITestMixin, TestCase):
         self.produtor = produtor.make()
         self.tecnico = tecnico.make()
         self.propriedade = propriedade.make(tecnico=self.tecnico)
-        self.url = reverse_lazy(
-            "propriedade-delete-tecnico", kwargs={'idPropriedade': self.propriedade.idPropriedade})
+        self.url = self.get_url()
+
+    def get_url(self, idPropriedade=None):
+        if idPropriedade is None:
+            idPropriedade = self.propriedade.idPropriedade
+        return reverse_lazy("propriedade-delete-tecnico", kwargs={'idPropriedade': idPropriedade})
 
     def test_deleta_tecnico_propriedade(self):
         self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.get_header_credencial(self.tecnico.usuario))
@@ -264,6 +270,15 @@ class PropriedadeDeleteTecnicoAPIView(APITestMixin, TestCase):
         self.assertEqual(data.tecnico, None)
         self.assertEqual(self.propriedade.tecnico, self.tecnico)
 
+    def test_nao_deleta_tecnico_propriedade_inexistente(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.get_header_credencial(self.tecnico.usuario))
+        url = self.get_url('00000000-0000-4000-8000-000000000000')
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, 404, response.json())
+        self.assertIn('Não encontrado.', response.json()['detail'])
+
     def test_nao_deleta_outro_tecnico_propriedade(self):
         outro_tecnico = tecnico.make()
         self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.get_header_credencial(outro_tecnico.usuario))
@@ -271,7 +286,7 @@ class PropriedadeDeleteTecnicoAPIView(APITestMixin, TestCase):
         response = self.client.delete(self.url)
         error_message = 'Somente o técnico que está atribuido a propriedade pode se remover'
 
-        self.assertEqual(response.status_code, 401, response.json())
+        self.assertEqual(response.status_code, 400, response.json())
         self.assertIn(error_message, response.json()['error'])
 
     def test_produtor_nao_deleta_tecnico_propriedade(self):
@@ -280,5 +295,5 @@ class PropriedadeDeleteTecnicoAPIView(APITestMixin, TestCase):
         response = self.client.delete(self.url)
         error_message = 'Um produtor não pode remover técnico da propriedade'
 
-        self.assertEqual(response.status_code, 401, response.json())
+        self.assertEqual(response.status_code, 400, response.json())
         self.assertIn(error_message, response.json()['error'])

--- a/propriedade/tests/views/test_propriedade.py
+++ b/propriedade/tests/views/test_propriedade.py
@@ -244,6 +244,7 @@ class PropriedadeHistoricoPlantioAPIView(APITestMixin, TestCase):
         self.assertEqual(Plantio.objects.count(), 6)
         self.assertEqual(len(response.json()), 3)
 
+
 class PropriedadeDeleteTecnicoAPIView(APITestMixin, TestCase):
 
     def setUp(self):
@@ -255,7 +256,6 @@ class PropriedadeDeleteTecnicoAPIView(APITestMixin, TestCase):
 
     def test_deleta_tecnico_propriedade(self):
         self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.get_header_credencial(self.tecnico.usuario))
-        propriedade_dois = propriedade.make()
 
         response = self.client.delete(self.url)
         data = Propriedade.objects.filter(idPropriedade=self.propriedade.idPropriedade)[0]

--- a/propriedade/tests/views/test_propriedade.py
+++ b/propriedade/tests/views/test_propriedade.py
@@ -264,7 +264,7 @@ class PropriedadeDeleteTecnicoAPIView(APITestMixin, TestCase):
         self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.get_header_credencial(self.tecnico.usuario))
 
         response = self.client.delete(self.url)
-        data = Propriedade.objects.filter(idPropriedade=self.propriedade.idPropriedade)[0]
+        data = Propriedade.objects.filter(idPropriedade=self.propriedade.idPropriedade).first()
 
         self.assertEqual(response.status_code, 204)
         self.assertEqual(data.tecnico, None)

--- a/propriedade/urls.py
+++ b/propriedade/urls.py
@@ -3,7 +3,7 @@ from core.consts.urls import UUID4_URL
 from django.conf.urls import url
 from django.urls import include
 
-from propriedade.views.propriedade import PropriedadeAPIView, PropriedadeHistoricoPlantioAPIView, PropriedadeRetrieveAPIView
+from propriedade.views.propriedade import PropriedadeAPIView, PropriedadeHistoricoPlantioAPIView, PropriedadeRetrieveAPIView, PropriedadeDeleteTecnicoAPIView
 
 
 urlpatterns = [
@@ -19,5 +19,10 @@ urlpatterns = [
             r'(?P<idPropriedade>{})/historico/plantio/$'.format(UUID4_URL),
             PropriedadeHistoricoPlantioAPIView.as_view(),
             name='propriedade-historico-plantio'),
+
+        url(
+            r'(?P<idPropriedade>{})/tecnico/$'.format(UUID4_URL),
+            PropriedadeDeleteTecnicoAPIView.as_view(),
+            name='propriedade-delete-tecnico'),
     ]))
 ]

--- a/propriedade/views/propriedade.py
+++ b/propriedade/views/propriedade.py
@@ -56,9 +56,9 @@ class PropriedadeDeleteTecnicoAPIView(DestroyAPIView):
         instance = self.get_object()
 
         if self.request.user.tipo != TECNICO:
-            return Response({"error": "Um produtor não pode remover técnico da propriedade"}, status=status.HTTP_401_UNAUTHORIZED)
+            return Response({"error": "Um produtor não pode remover técnico da propriedade"}, status=status.HTTP_400_BAD_REQUEST)
         if self.request.user.idUsuario != instance.tecnico.usuario_id:
-            return Response({"error": "Somente o técnico que está atribuido a propriedade pode se remover"}, status=status.HTTP_401_UNAUTHORIZED)
+            return Response({"error": "Somente o técnico que está atribuido a propriedade pode se remover"}, status=status.HTTP_400_BAD_REQUEST)
 
         self.perform_destroy(instance.tecnico)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/propriedade/views/propriedade.py
+++ b/propriedade/views/propriedade.py
@@ -10,7 +10,7 @@ from talhao.models import Talhao
 
 from rest_framework.generics import ListCreateAPIView, RetrieveAPIView, ListAPIView, DestroyAPIView
 from rest_framework.response import Response
-from rest_framework import status,viewsets
+from rest_framework import status
 
 
 class PropriedadeAPIView(ListCreateAPIView):
@@ -54,9 +54,11 @@ class PropriedadeDeleteTecnicoAPIView(DestroyAPIView):
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
+
         if self.request.user.tipo != TECNICO:
             return Response({"error": "Um produtor não pode remover técnico da propriedade"}, status=status.HTTP_401_UNAUTHORIZED)
         if self.request.user.idUsuario != instance.tecnico.usuario_id:
             return Response({"error": "Somente o técnico que está atribuido a propriedade pode se remover"}, status=status.HTTP_401_UNAUTHORIZED)
+
         self.perform_destroy(instance.tecnico)
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Descrição
<!-- - Descreva aqui as alterações a serem implementadas no projeto -->
Adicionando endpoint DELETE para deletar o técnico de uma propriedade 

## Está consertando alguma issue aberta?
<!-- - Se sim, informe aqui -->
- [#171](https://github.com/UnBArqDsw2021-2/2021.2_G4_CadernetaDeCampoDigital_docs/issues/171)

## Tarefas gerais realizadas
- Adição do endpoint de DELETE
- Adição de testes